### PR TITLE
add back cmd/apiserver/main.go as a k8s api server skeleton for test purpose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,12 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+APISERVER-BOOT = $(shell pwd)/bin/apiserver-boot
+.PHONY: apiserver-boot
+apiserver-local: ## Download apiserver-boot cmd locally if necessary.
+	$(call go-get-tool,$(APISERVER-BOOT),sigs.k8s.io/apiserver-builder-alpha/cmd/apiserver-boot@v1.23.0)
+	$(APISERVER-BOOT) run local --run etcd,apiserver
+
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ test: manifests generate fmt vet envtest ## Run tests.
 
 .PHONY: build
 build: generate fmt vet ## Build binary.
+	go build ./...
+	go build -o bin/apiserver cmd/apiserver/main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run from your host.

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
+	apiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/klog"
+	"sigs.k8s.io/apiserver-runtime/pkg/builder"
+
+	// +kubebuilder:scaffold:resource-imports
+	fornaxv1 "centaurusinfra.io/fornax-serverless/pkg/apis/core/v1"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	fornaxv1.AddToScheme(scheme)
+}
+
+func main() {
+	storageFunc := func(scheme *runtime.Scheme, store *registry.Store, option *generic.StoreOptions) {
+		store.AfterCreate = func(obj runtime.Object, options *metav1.CreateOptions) {
+			fmt.Println(obj)
+		}
+		store.AfterUpdate = func(obj runtime.Object, options *metav1.UpdateOptions) {
+			fmt.Println(obj)
+		}
+		store.AfterDelete = func(obj runtime.Object, options *metav1.DeleteOptions) {
+			fmt.Println(obj)
+		}
+	}
+
+	err := builder.APIServer.
+		WithLocalDebugExtension().
+		WithResourceAndStorage(&fornaxv1.Application{}, storageFunc).
+		WithResourceAndStorage(&fornaxv1.ApplicationInstance{}, storageFunc).
+		WithResourceAndStorage(&fornaxv1.ApplicationSession{}, storageFunc).
+		WithResourceAndStorage(&fornaxv1.ClientSession{}, storageFunc).
+		WithResourceAndStorage(&fornaxv1.IngressEndpoint{}, storageFunc).
+		WithConfigFns(func(config *apiserver.RecommendedConfig) *apiserver.RecommendedConfig {
+			fmt.Printf("%T\n", config.Authentication.Authenticator)
+			fmt.Println(config.Authentication.APIAudiences)
+			return config
+		}).
+		Execute()
+	if err != nil {
+		klog.Fatal(err)
+	}
+}

--- a/hack/fornax_curl.zshrc
+++ b/hack/fornax_curl.zshrc
@@ -1,0 +1,21 @@
+fornax_post() {
+ echo curl -H 'Content-Type: application/yaml' -X POST -d "$(cat $3)" http://127.0.0.1:8001/apis/core.fornax-serverless.centaurusinfra.io/v1/namespaces/$1/$2
+ curl -H 'Content-Type: application/yaml' -X POST -d "$(cat $3)" http://127.0.0.1:8001/apis/core.fornax-serverless.centaurusinfra.io/v1/namespaces/$1/$2
+}
+
+fornax_get() {
+ echo curl -H 'Content-Type: application/yaml' -X GET http://127.0.0.1:8001/apis/core.fornax-serverless.centaurusinfra.io/v1/namespaces/$1/$2/$3
+ curl -H 'Content-Type: application/yaml' -X GET http://127.0.0.1:8001/apis/core.fornax-serverless.centaurusinfra.io/v1/namespaces/$1/$2/$3
+}
+
+fornax_application_post() {
+ echo curl -H 'Content-Type: application/yaml' -X POST -d "$(cat $3)" http://127.0.0.1:8001/apis/core.fornax-serverless.centaurusinfra.io/v1/namespaces/$1/applications/$2/abcs
+ curl -H 'Content-Type: application/yaml' -X POST -d "$(cat $3)" http://127.0.0.1:8001/apis/core.fornax-serverless.centaurusinfra.io/v1/namespaces/$1/application/$2/abcs
+}
+
+kube_post() {
+ echo curl -H 'Content-Type: application/yaml' -X POST -d "$(cat $3)" http://127.0.0.1:8001/apis/k8s.io/v1/namespaces/$1/$2
+ curl -H 'Content-Type: application/yaml' -X POST -d "$(cat $3)" http://127.0.0.1:8001/apis/k8s.io/v1/namespaces/$1/$2
+}
+
+alias kubeproxy='kubectl --kubeconfig kubeconfig proxy --address localhost'

--- a/hack/test-data/application.yaml
+++ b/hack/test-data/application.yaml
@@ -5,32 +5,32 @@ metadata:
   labels:
     name: nginx-undo
 spec:
-  session_config:
-    num_of_session_of_instance: 1
-    min_sessions: 1
-    max_sessions: 10
-    max_surge: 1
-    min_of_idle_sessions: 0
+  sessionConfig:
+    numOfSessionOfInstance: 1
+    minSessions: 1
+    maxSessions: 10
+    maxSurge: 1
+    minOfIdleSessions: 0
   container:
     image: nginx
     name: nginx
-  working_mode: Standlone
-  config_data:
+  workingMode: Standlone
+  configData:
     config1: data1
     config2: data2
 status:
-  deployement_status: Progressing
-  deployment_time: 2020-10-01T12:00:00.000Z
-  desired_instances: 10
-  available_instances: 1
+  deployementStatus: Progressing
+  deploymentTime: 2020-10-01T12:00:00.000Z
+  desiredInstances: 10
+  availableInstances: 1
   history:
     - status: Progressing
       action: createInstance
-      update_time: 2020-10-01T10:00:00.000Z
-      instance_reference:
+      updateTime: 2020-10-01T10:00:00.000Z
+      instanceReference:
         name: nginx-instance-1
     - status: Progressing
       action: deleteInstance
-      update_time: 2020-10-01T10:00:00.000Z
-      instance_reference:
+      updateTime: 2020-10-01T10:00:00.000Z
+      instanceReference:
         name: nginx-instance-0

--- a/hack/test-data/application_instance.yaml
+++ b/hack/test-data/application_instance.yaml
@@ -10,23 +10,23 @@ metadata:
       name: nginx2
       uid: ad834522-d9a5-4841-beac-991ff3798c00
 spec:
-  application_name: nginx-instance-1
-  instance_name: nginx-instance-1
-  instance_interfaces:
-    - ip_address: 10.0.0.1
+  applicationName: nginx-instance-1
+  instanceName: nginx-instance-1
+  instanceInterfaces:
+    - ipAddress: 10.0.0.1
       vpc: my-nice-vpc
 status:
   status: standby
   history:
-    - pod_reference:
+    - podReference:
         name: nginx-instance-pod-2
       action: createPod
-      update_time: 2020-10-01T12:00:00.000Z
-    - pod_reference:
+      updateTime: 2020-10-01T12:00:00.000Z
+    - podReference:
         name: nginx-instance-pod-1
       action: deletePod
-      update_time: 2020-10-01T11:00:00.000Z
-    - pod_reference:
+      updateTime: 2020-10-01T11:00:00.000Z
+    - podReference:
         name: nginx-instance-pod-1
       action: createPod
-      update_time: 2020-10-01T10:00:00.000Z
+      updateTime: 2020-10-01T10:00:00.000Z

--- a/hack/test-data/application_session.yaml
+++ b/hack/test-data/application_session.yaml
@@ -5,14 +5,16 @@ metadata:
   labels:
     application: nginx2
 spec:
-  session_name: my-nginx2-session
-  session_data: my-nginx2-session-data
+  sessionName: my-nginx2-session
+  sessionData: my-nginx2-session-data
 status:
-  session_status: Allocated
-  client_sessions:
+  ingressEndpointReference:
+    name: endpoint-reference-1
+  sessionStatus: Allocated
+  clientSessions:
     - name: client-session-1
   history:
     - action: ClientJoin
-      update_time: 2020-10-01T10:00:00.000Z
-      client_session:
+      updateTime: 2020-10-01T10:00:00.000Z
+      clientSession:
         name: client-session-1

--- a/hack/test-data/ingress_endpoint.yaml
+++ b/hack/test-data/ingress_endpoint.yaml
@@ -15,13 +15,13 @@ metadata:
     name: nginx-endpoint
 spec:
   protocol: TCP
-  ingress_gwip_address: 172.13.0.1
-  ingress_port: 30001
+  ingressGwipAddress: 172.13.0.1
+  ingressPort: 30001
   destinations:
-    - ip_address: 192.168.1
+    - ipAddress: 192.168.1
       port: 8000
 status:
-  service_status: Idle
+  serviceStatus: Idle
   history:
     - action: SetupIngressRule
-      update_time: 2020-10-01T10:00:00.000Z
+      updateTime: 2020-10-01T10:00:00.000Z


### PR DESCRIPTION
how to run a local test apiserver and etcd, 
```
[api-server-skeleton] # make apiserver-local                                                                                                                                                                                                                                 ~/Go/src/centaurusinfra.io/fornax-serverless
/home/wguo/Go/src/centaurusinfra.io/fornax-serverless/bin/apiserver-boot run local --run etcd,apiserver
I0524 15:44:51.948425   21241 build_executables.go:180] CGO_ENABLED=0
I0524 15:44:51.948471   21241 build_executables.go:190] go build -o bin/apiserver cmd/apiserver/main.go
I0524 15:44:53.636014   21241 local.go:264] Writing kubeconfig to kubeconfig
I0524 15:44:53.636147   21241 local.go:240] Starting local component: etcd
I0524 15:44:55.656915   21241 local.go:180] The apiserver binary supports local-running, proceeding..
I0524 15:44:55.656983   21241 local.go:240] Starting local component: bin/apiserver --etcd-servers=http://localhost:2379 --secure-port=9443 --feature-gates=APIPriorityAndFairness=false --standalone-debug-mode --bind-address=127.0.0.1
W0524 15:44:55.894819   21375 authentication.go:316] No authentication-kubeconfig provided in order to lookup client-ca-file in configmap/extension-apiserver-authentication in kube-system, so client certificate authentication won't work.
W0524 15:44:55.894869   21375 authentication.go:340] No authentication-kubeconfig provided in order to lookup requestheader-client-ca-file in configmap/extension-apiserver-authentication in kube-system, so request-header client certificate authentication won't work.
authenticator.RequestFunc
[]
I0524 15:44:55.907475   21375 secure_serving.go:266] Serving securely on 127.0.0.1:9443
I0524 15:44:55.907492   21375 dynamic_serving_content.go:131] "Starting controller" name="serving-cert::apiserver.local.config/certificates/apiserver.crt::apiserver.local.config/certificates/apiserver.key"
I0524 15:44:55.907506   21375 tlsconfig.go:240] "Starting DynamicServingCertificateController"
I0524 15:44:57.657238   21241 local.go:132] Aggregated apiserver successfully started
I0524 15:44:57.657308   21241 local.go:141]
==================================================
| Now you're all set!
| To test the server, try the following commands:
|
| >> "kubectl --kubeconfig kubeconfig api-versions" or "KUBECONFIG=kubeconfig kubectl api-resources"
|
==================================================
```


