### PR TITLE
fornax test report improve

### DIFF
--- a/cmd/fornaxtest/config/test_config.go
+++ b/cmd/fornaxtest/config/test_config.go
@@ -24,7 +24,8 @@ type TestConfiguration struct {
 	NumOfTestCycle      int
 	NumOfApps           int
 	NumOfInitPodsPerApp int
-	BurstOfPodPerApp    int
+	NumOfAppPerSec      int
+	NumOfSessionPerSec  int
 	NumOfSessionPerApp  int
 }
 
@@ -41,7 +42,8 @@ func AddConfigFlags(flagSet *pflag.FlagSet, simuConfig *TestConfiguration) {
 	flagSet.StringVar(&simuConfig.TestCase, "test-case", simuConfig.TestCase, "which test is running, app_full_cycle,session_full_cycle,session_create")
 	flagSet.IntVar(&simuConfig.NumOfApps, "num-of-app", simuConfig.NumOfApps, "how many applications are simulated")
 	flagSet.IntVar(&simuConfig.NumOfInitPodsPerApp, "num-of-init-pod-per-app", simuConfig.NumOfInitPodsPerApp, "how many applications pods are precreated when create app")
-	flagSet.IntVar(&simuConfig.BurstOfPodPerApp, "burst-of-pod-per-app", simuConfig.BurstOfPodPerApp, "maximum pods are allowed in one batch for a application")
+	flagSet.IntVar(&simuConfig.NumOfSessionPerSec, "num-of-session-per-sec", simuConfig.NumOfSessionPerSec, "maximum session to created in one second for a application")
+	flagSet.IntVar(&simuConfig.NumOfAppPerSec, "num-of-app-per-sec", simuConfig.NumOfAppPerSec, "maximum app to created in one second")
 	flagSet.IntVar(&simuConfig.NumOfSessionPerApp, "num-of-session-per-app", simuConfig.NumOfSessionPerApp, "how many application sessions are created for a application")
 	flagSet.IntVar(&simuConfig.NumOfTestCycle, "num-of-test-cycle", simuConfig.NumOfSessionPerApp, "how many test run before exit")
 }
@@ -51,7 +53,8 @@ func DefaultConfiguration() *TestConfiguration {
 		TestCase:            AppFullCycleTest,
 		NumOfApps:           1,
 		NumOfInitPodsPerApp: 0,
-		BurstOfPodPerApp:    10,
+		NumOfAppPerSec:      50,
+		NumOfSessionPerSec:  50,
 		NumOfSessionPerApp:  1,
 		NumOfTestCycle:      1,
 	}

--- a/cmd/simulation/node/app/snode/node_actor.go
+++ b/cmd/simulation/node/app/snode/node_actor.go
@@ -401,14 +401,13 @@ func (n *SimulationNodeActor) onSessionOpenCommand(msg *fornaxgrpc.SessionOpen) 
 			ClientSessions: map[string]*fornaxtypes.ClientSession{},
 		}
 		func() {
-			time.Sleep(30 * time.Millisecond)
+			time.Sleep(3 * time.Millisecond)
 			n.nodeMutex.Lock()
 			defer n.nodeMutex.Unlock()
 			revision := n.incrementNodeRevision()
 			sess.ResourceVersion = fmt.Sprint(revision)
 			fpod.Sessions[sessId] = fsess
 			fsess.Session.Status.SessionStatus = fornaxv1.SessionStatusAvailable
-			fsess.Session.Status.AvailableTime = util.NewCurrentMetaTime()
 			n.notify(n.fornoxCoreRef, session.BuildFornaxcoreGrpcSessionState(revision, fsess))
 		}()
 	}
@@ -426,7 +425,7 @@ func (n *SimulationNodeActor) onSessionCloseCommand(msg *fornaxgrpc.SessionClose
 	} else {
 		if fsess, found := fpod.Sessions[sessId]; found {
 			func() {
-				time.Sleep(30 * time.Millisecond)
+				time.Sleep(3 * time.Millisecond)
 				n.nodeMutex.Lock()
 				defer n.nodeMutex.Unlock()
 				revision := n.incrementNodeRevision()


### PR DESCRIPTION
use milli second for session setup time unit in test report, and print app setup percentile, add flag to control how many session create per sec for a app