### PR TITLE
 use shared kubeconfig to create api client

### DIFF
--- a/cmd/fornaxtest/app/test_runner.go
+++ b/cmd/fornaxtest/app/test_runner.go
@@ -30,23 +30,26 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/apimachinery/pkg/util/rand"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	// "k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
+
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
 	"k8s.io/component-base/version/verflag"
+)
+
+var (
+	allTestApps         = TestApplicationArray{}
+	allTestSessions     = TestSessionArray{}
+	appSessionMap       = TestSessionMap{}
+	appSessionMapLock   = sync.Mutex{}
+	testSessionCounters = []*TestSessionCounter{}
 )
 
 type TestSessionCounter struct {
 	numOfSessions int
 	st            int64
 	et            int64
-}
-
-func init() {
-	utilruntime.Must(logs.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 }
 
 const (
@@ -105,10 +108,11 @@ func Run(ctx context.Context, testConfig config.TestConfiguration) {
 
 	RunTest := func(appName string) {
 		klog.Infof("--------App %s Test begin--------\n", appName)
+		namespace := "fornaxtest"
+		randAppName := rand.String(16)
 		for i := 1; i <= testConfig.NumOfTestCycle; i++ {
 			sessions := []*TestSession{}
-			cycleName := fmt.Sprintf("%s-cycle-%d", rand.String(16), i)
-			namespace := "fornaxtest"
+			cycleName := fmt.Sprintf("%s-cycle-%d", randAppName, i)
 			switch testConfig.TestCase {
 			case config.AppFullCycleTest:
 				sessions = runAppFullCycleTest(cycleName, namespace, appName, testConfig)

--- a/pkg/fornaxcore/application/application_manager.go
+++ b/pkg/fornaxcore/application/application_manager.go
@@ -174,7 +174,7 @@ func (am *ApplicationManager) getOrCreateApplicationPool(applicationKey string) 
 }
 
 func (am *ApplicationManager) initApplicationInformer(ctx context.Context) {
-	apiServerClient := util.GetFornaxCoreApiClient()
+	apiServerClient := util.GetFornaxCoreApiClient(util.GetFornaxCoreKubeConfig())
 	appInformerFactory := externalversions.NewSharedInformerFactory(apiServerClient, 10*time.Minute)
 
 	applicationInformer := appInformerFactory.Core().V1().Applications()
@@ -205,7 +205,7 @@ func (am *ApplicationManager) initApplicationInformer(ctx context.Context) {
 }
 
 func (am *ApplicationManager) initApplicationSessionInformer(ctx context.Context) {
-	apiServerClient := util.GetFornaxCoreApiClient()
+	apiServerClient := util.GetFornaxCoreApiClient(util.GetFornaxCoreKubeConfig())
 	sessionInformerFactory := externalversions.NewSharedInformerFactory(apiServerClient, 10*time.Minute)
 	applicationSessionInformer := sessionInformerFactory.Core().V1().ApplicationSessions()
 	applicationSessionInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/fornaxcore/node/node_manager.go
+++ b/pkg/fornaxcore/node/node_manager.go
@@ -53,7 +53,7 @@ type nodeManager struct {
 	houseKeepingTicker *time.Ticker
 }
 
-// UpdateSessionState implements NodeManager
+// UpdateSessionState implements NodeManagerInterface
 func (nm *nodeManager) UpdateSessionState(nodeIdentifier string, session *fornaxv1.ApplicationSession) error {
 	podName := session.Status.PodReference.Name
 	pod := nm.podManager.FindPod(podName)
@@ -65,7 +65,7 @@ func (nm *nodeManager) UpdateSessionState(nodeIdentifier string, session *fornax
 	return nil
 }
 
-// WatchNode implements NodeManager
+// WatchNode implements NodeManagerInterface
 func (nm *nodeManager) Watch(watcher chan<- interface{}) {
 	nm.watchers = append(nm.watchers, watcher)
 }

--- a/pkg/util/api_client.go
+++ b/pkg/util/api_client.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/klog/v2"
 )
 
-func GetFornaxCoreApiClient() *fornaxclient.Clientset {
+func GetFornaxCoreKubeConfig() *rest.Config {
 	var kubeconfig *rest.Config
 	if root, err := os.Getwd(); err == nil {
 		kubeconfigPath := root + "/kubeconfig"
@@ -37,7 +37,9 @@ func GetFornaxCoreApiClient() *fornaxclient.Clientset {
 		klog.ErrorS(err, "Failed to get working dir")
 		os.Exit(-1)
 	}
+	return kubeconfig
+}
+func GetFornaxCoreApiClient(kubeconfig *rest.Config) *fornaxclient.Clientset {
 	apiServerClient := fornaxclient.NewForConfigOrDie(kubeconfig)
 	return apiServerClient
-
 }


### PR DESCRIPTION
 avoid keep initialize kubeconfig, it could cause too many open fd