### PR TITLE
add revision to update record of nodeagent managed resources db

### DIFF
--- a/cmd/fornaxtest/app/test.go
+++ b/cmd/fornaxtest/app/test.go
@@ -55,11 +55,11 @@ var (
 			Resources: v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					"memory": util.ResourceQuantity(50*1024*1024, v1.ResourceMemory),
-					"cpu":    util.ResourceQuantity(0.1*1000, v1.ResourceCPU),
+					"cpu":    util.ResourceQuantity(0.05*1000, v1.ResourceCPU),
 				},
 				Requests: map[v1.ResourceName]resource.Quantity{
 					"memory": util.ResourceQuantity(50*1024*1024, v1.ResourceMemory),
-					"cpu":    util.ResourceQuantity(0.1*1000, v1.ResourceCPU),
+					"cpu":    util.ResourceQuantity(0.05*1000, v1.ResourceCPU),
 				},
 			},
 		}},

--- a/pkg/fornaxcore/nodemonitor/node_monitor.go
+++ b/pkg/fornaxcore/nodemonitor/node_monitor.go
@@ -280,7 +280,6 @@ func (nm *nodeMonitor) updateOrCreateNode(nodeId string, v1node *v1.Node, revisi
 			NodeIdentifier: nodeId,
 			Revision:       revision,
 		})
-		// somehow node already register with other fornax cores
 		_, err := nm.nodeManager.CreateNode(nodeId, v1node)
 		if err != nil {
 			klog.ErrorS(err, "Failed to create a node", "node", v1node)

--- a/pkg/fornaxcore/pod/pod_manager.go
+++ b/pkg/fornaxcore/pod/pod_manager.go
@@ -278,12 +278,12 @@ func (pm *podManager) AddPod(nodeId string, pod *v1.Pod) (*v1.Pod, error) {
 					return nil, err
 				}
 			}
+			util.MergePod(pod, podInCache)
 			switch {
 			case util.PodIsTerminated(pod):
 				pm.podStateMap.deletePod(fornaxPodState)
 				pm.podUpdates <- &ie.PodEvent{NodeId: nodeId, Pod: podInCache.DeepCopy(), Type: ie.PodEventTypeTerminate}
 			default:
-				util.MergePod(podInCache, pod)
 				fornaxPodState.v1pod = podInCache.DeepCopy()
 				fornaxPodState.nodeId = nodeId
 				pm.podUpdates <- &ie.PodEvent{NodeId: nodeId, Pod: podInCache.DeepCopy(), Type: ie.PodEventTypeUpdate}

--- a/pkg/nodeagent/node/node.go
+++ b/pkg/nodeagent/node/node.go
@@ -225,7 +225,6 @@ func LoadPodsFromContainerRuntime(runtimeService runtime.RuntimeService, db *sto
 					}
 					world.terminatedPods = append(world.terminatedPods, fornaxpod)
 				}
-				db.PutPod(fornaxpod)
 			} else {
 				// got error, can not make decision, will retry
 				return world, err

--- a/pkg/nodeagent/store/storefactory.go
+++ b/pkg/nodeagent/store/storefactory.go
@@ -59,11 +59,11 @@ func (s *NodeStore) GetNode(identifier string) (*types.FornaxNodeWithRevision, e
 	}
 }
 
-func (s *NodeStore) PutNode(node *types.FornaxNodeWithRevision) error {
+func (s *NodeStore) PutNode(node *types.FornaxNodeWithRevision, revision int64) error {
 	if node == nil {
 		return fmt.Errorf("nil node is passed")
 	}
-	err := s.PutObject(node.Identifier, node)
+	err := s.PutObject(node.Identifier, node, revision)
 	if err != nil {
 		return err
 	}
@@ -92,11 +92,11 @@ func (s *PodStore) GetPod(identifier string) (*types.FornaxPod, error) {
 	}
 }
 
-func (s *PodStore) PutPod(pod *types.FornaxPod) error {
+func (s *PodStore) PutPod(pod *types.FornaxPod, revision int64) error {
 	if pod == nil {
 		return fmt.Errorf("nil pod is passed")
 	}
-	err := s.PutObject(string(pod.Identifier), pod)
+	err := s.PutObject(pod.Identifier, pod, revision)
 	if err != nil {
 		return err
 	}
@@ -125,11 +125,11 @@ func (s *SessionStore) GetSession(identifier string) (*types.FornaxSession, erro
 	}
 }
 
-func (s *SessionStore) PutSession(session *types.FornaxSession) error {
+func (s *SessionStore) PutSession(session *types.FornaxSession, revision int64) error {
 	if session == nil {
 		return fmt.Errorf("nil session is passed")
 	}
-	err := s.PutObject(session.Identifier, session)
+	err := s.PutObject(session.Identifier, session, revision)
 	if err != nil {
 		return err
 	}

--- a/pkg/nodeagent/store/test/storefactory.go
+++ b/pkg/nodeagent/store/test/storefactory.go
@@ -30,10 +30,10 @@ func main() {
 	count := 100
 	for i := 0; i <= count; i++ {
 		id := fmt.Sprint(i)
-		podstore.PutPod(&fornaxtypes.FornaxPod{Identifier: id, Pod: &v1.Pod{}, ConfigMap: &v1.ConfigMap{}})
+		podstore.PutPod(&fornaxtypes.FornaxPod{Identifier: id, Pod: &v1.Pod{}, ConfigMap: &v1.ConfigMap{}}, int64(i))
 		podstore.GetPod(id)
 
-		sessionstore.PutSession(&fornaxtypes.FornaxSession{Identifier: id})
+		sessionstore.PutSession(&fornaxtypes.FornaxSession{Identifier: id}, int64(i))
 		sessionstore.GetSession(id)
 
 		fmt.Println("get no 99 pod,session")

--- a/pkg/store/storage/interface.go
+++ b/pkg/store/storage/interface.go
@@ -30,19 +30,11 @@ type RevisionObject struct {
 	Revision int64
 }
 
-type StoreWithRevision interface {
-	ListObject(rev int64) ([]*RevisionObject, error)
-	DelObject(key string, rev int64) error
-	GetObject(key string) (*RevisionObject, error)
-	PutObject(key string, obj interface{}, rev int64) (int64, error)
-	Watch(key string, rev int64, updateCh chan *RevisionEvent) error
-}
-
 type Store interface {
 	ListObject() ([]interface{}, error)
 	DelObject(key string) error
 	GetObject(key string) (interface{}, error)
-	PutObject(key string, obj interface{}) error
+	PutObject(key string, obj interface{}, revision int64) error
 }
 
 type TextFromObjectFunc func(interface{}) ([]byte, error)

--- a/pkg/util/meta.go
+++ b/pkg/util/meta.go
@@ -68,32 +68,32 @@ func Name(obj interface{}) string {
 	return name
 }
 
-func MergeObjectMeta(oldMeta *metav1.ObjectMeta, newMeta *metav1.ObjectMeta) {
-	oldMeta.ResourceVersion = newMeta.ResourceVersion
+func MergeObjectMeta(fromMeta, toMeta *metav1.ObjectMeta) {
+	toMeta.ResourceVersion = fromMeta.ResourceVersion
 
 	labels := map[string]string{}
-	for k, v := range oldMeta.GetLabels() {
+	for k, v := range toMeta.GetLabels() {
 		labels[k] = v
 	}
-	for k, v := range newMeta.GetLabels() {
+	for k, v := range fromMeta.GetLabels() {
 		labels[k] = v
 	}
-	oldMeta.Labels = labels
+	toMeta.Labels = labels
 
 	annotations := map[string]string{}
-	for k, v := range oldMeta.GetAnnotations() {
+	for k, v := range toMeta.GetAnnotations() {
 		annotations[k] = v
 	}
-	for k, v := range newMeta.GetAnnotations() {
+	for k, v := range fromMeta.GetAnnotations() {
 		annotations[k] = v
 	}
-	oldMeta.Annotations = annotations
+	toMeta.Annotations = annotations
 
-	if newMeta.DeletionTimestamp != nil && oldMeta.DeletionTimestamp == nil {
-		oldMeta.DeletionTimestamp = newMeta.DeletionTimestamp
+	if fromMeta.DeletionTimestamp != nil && toMeta.DeletionTimestamp == nil {
+		toMeta.DeletionTimestamp = fromMeta.DeletionTimestamp
 	}
 
-	if newMeta.DeletionGracePeriodSeconds != nil && oldMeta.DeletionGracePeriodSeconds == nil {
-		oldMeta.DeletionGracePeriodSeconds = newMeta.DeletionGracePeriodSeconds
+	if fromMeta.DeletionGracePeriodSeconds != nil && toMeta.DeletionGracePeriodSeconds == nil {
+		toMeta.DeletionGracePeriodSeconds = fromMeta.DeletionGracePeriodSeconds
 	}
 }

--- a/pkg/util/pod.go
+++ b/pkg/util/pod.go
@@ -170,8 +170,8 @@ func GetPodResourceList(v1pod *v1.Pod) *v1.ResourceList {
 	return &resourceList
 }
 
-func MergePod(toPod, fromPod *v1.Pod) {
-	MergeObjectMeta(&toPod.ObjectMeta, &fromPod.ObjectMeta)
+func MergePod(fromPod, toPod *v1.Pod) {
+	MergeObjectMeta(&fromPod.ObjectMeta, &toPod.ObjectMeta)
 
 	if PodIsTerminated(fromPod) {
 		if toPod.DeletionTimestamp == nil {


### PR DESCRIPTION
sqlite db transaction is slower, have to execute update in go routine, but it could increase revision race condition chance, add revision check to update resource record in node agent sqlite db to avoid overwrite newer revision.